### PR TITLE
no longer memory manage hash symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ clean: deps
 deps:
 	rm -rf dep
 
-PROF_SRC=fib20
+PROF_SRC=interpreter
 
 profile: all
 	rm -f callgrind.out.*
@@ -204,7 +204,7 @@ profile: all
 	valgrind --tool=callgrind ./$(TARGET) --binary-in=$(PROF_SRC).fnc
 
 leak-check: all
-	valgrind --leak-check=full ./$(TARGET) fn//$(PROF_SRC).fn
+	valgrind --leak-check=full ./$(TARGET) fn/$(PROF_SRC).fn
 
 indent: indent-src indent-generated
 

--- a/src/hash.c
+++ b/src/hash.c
@@ -213,10 +213,9 @@ void markHashTable(HashTable *table) {
     if (MARKED(table))
         return;
     MARK(table);
-    for (Index i = 0; i < table->capacity; i++) {
-        if (table->keys[i] != NULL) {
-            markHashSymbol(table->keys[i]);
-            if (table->valuesize > 0 && table->markfunction != NULL) {
+    if (table->valuesize > 0 && table->markfunction != NULL) {
+        for (Index i = 0; i < table->capacity; i++) {
+            if (table->keys[i] != NULL) {
                 DEBUG("markHashTable() [%d][%d][%p]", table->id, i,
                       (char *) table->values + (i * table->valuesize));
                 table->markfunction((char *) table->values +
@@ -249,12 +248,10 @@ HashSymbol *uniqueHashSymbol(HashTable *table, char *name, void *src) {
     if (x != NULL) {
         return x;
     }
-    x = NEW(HashSymbol, OBJTYPE_HASHSYMBOL);
-    int save = PROTECT(x);
+    x = ALLOCATE(HashSymbol);
     x->name = safeStrdup(name);
     x->hash = hashString(name);
     hashSet(table, x, src);
-    UNPROTECT(save);
     return x;
 }
 
@@ -337,8 +334,4 @@ void markHashSymbol(HashSymbol *x) {
     if (MARKED(x))
         return;
     MARK(x);
-}
-
-void freeHashSymbol(HashSymbol *x) {
-    FREE(x, HashSymbol);
 }

--- a/src/hash.h
+++ b/src/hash.h
@@ -64,7 +64,6 @@ HashSymbol *hashGetVar(HashTable *table, const char *name);
 HashSymbol *uniqueHashSymbol(HashTable *table, char *name, void *valuePtr);
 
 void markHashSymbol(HashSymbol *x);
-void freeHashSymbol(HashSymbol *x);
 
 extern bool quietPrintHashTable;
 
@@ -77,8 +76,5 @@ void markHashTable(HashTable *table);
 
 static inline void markHashSymbolObj(struct Header *h) {
     markHashSymbol((HashSymbol *) h);
-}
-static inline void freeHashSymbolObj(struct Header *h) {
-    freeHashSymbol((HashSymbol *) h);
 }
 #endif

--- a/src/memory.c
+++ b/src/memory.c
@@ -70,8 +70,6 @@ const char *typeName(ObjType type, void *p) {
     switch (type) {
         case OBJTYPE_OPAQUE:
             return "opaque";
-        case OBJTYPE_HASHSYMBOL:
-            return "var";
         case OBJTYPE_CLO:
             return "clo";
         case OBJTYPE_ENV:
@@ -289,9 +287,6 @@ void markObj(Header *h, Index i) {
         case OBJTYPE_HASHTABLE:
             markHashTableObj(h);
             break;
-        case OBJTYPE_HASHSYMBOL:
-            markHashSymbolObj(h);
-            break;
         case OBJTYPE_PROTECTION:
             markProtectionObj(h);
             break;
@@ -345,9 +340,6 @@ void freeObj(Header *h) {
             break;
         case OBJTYPE_HASHTABLE:
             freeHashTableObj(h);
-            break;
-        case OBJTYPE_HASHSYMBOL:
-            freeHashSymbolObj(h);
             break;
         case OBJTYPE_PROTECTION:
             freeProtectionObj(h);

--- a/src/memory.h
+++ b/src/memory.h
@@ -39,7 +39,6 @@ typedef enum {
 
     // hash table types
     OBJTYPE_HASHTABLE,
-    OBJTYPE_HASHSYMBOL,
 
     OBJTYPE_PROTECTION,
     OBJTYPE_BIGINT,

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -89,12 +89,7 @@ HashSymbol *_genSym(char *prefix, GenSymFmt fmt) {
                 break;
         }
         if (hashGetVar(symbolTable, buffer) == NULL) {
-            HashSymbol *x = NEW(HashSymbol, OBJTYPE_HASHSYMBOL);
-            int save = PROTECT(x);
-            x->name = safeStrdup(buffer);
-            x->hash = hashString(buffer);
-            hashSet(symbolTable, x, NULL);
-            UNPROTECT(save);
+            HashSymbol *x = uniqueHashSymbol(symbolTable, buffer, NULL);
             hashSet(genSymTable, base, &symbolCounter);
             return x;
         }


### PR DESCRIPTION
Since hash symbols are globally unique and persist for the lifetime of the process there is no point in memory-managing them, this means that hash tables need only mark their contents and then only if those contents are memory managed. This results in about a 15% improvement in performance.