### PR TITLE
Add shared Unicode data pipeline and expose casing/numeric builtins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ EXTRA_TARGETS= \
     $(EXTRA_DEBUG_H_TARGETS) \
     $(EXTRA_DEBUG_C_TARGETS) \
 	$(GENDIR)/UnicodeData.inc \
+	$(GENDIR)/UnicodeCasing.inc \
 	$(GENDIR)/UnicodeDigits.inc \
+	$(GENDIR)/UnicodeNumbers.inc \
 	$(GENDIR)/anf_kont.h \
 	$(GENDIR)/anf_kont.c \
 	$(GENDIR)/anf_kont_objtypes.h \
@@ -330,11 +332,20 @@ $(UNIDIR)/UnicodeData.csv: $(UNIDIR)/UnicodeData.txt ./tools/convertCsv.py
 $(UNIDIR)/UnicodeData.txt: | $(UNIDIR)
 	wget -P $(UNIDIR) https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
 
-$(GENDIR)/UnicodeData.inc: $(UNIDIR)/UnicodeData.txt tools/makeUnicodeData.py | $(GENDIR)
-	$(PYTHON) ./tools/makeUnicodeData.py > $@
+$(UNIDIR)/SpecialCasing.txt: | $(UNIDIR)
+	wget -P $(UNIDIR) https://www.unicode.org/Public/UCD/latest/ucd/SpecialCasing.txt
 
-$(GENDIR)/UnicodeDigits.inc: $(UNIDIR)/UnicodeData.txt tools/makeUnicodeDigits.py | $(GENDIR)
-	$(PYTHON) ./tools/makeUnicodeDigits.py > $@
+$(GENDIR)/UnicodeData.inc: $(UNIDIR)/UnicodeData.txt $(UNIDIR)/SpecialCasing.txt tools/makeUnicodeData.py tools/unicode_table.py | $(GENDIR)
+	$(PYTHON) ./tools/makeUnicodeData.py $(UNIDIR)/UnicodeData.txt $(UNIDIR)/SpecialCasing.txt > $@
+
+$(GENDIR)/UnicodeDigits.inc: $(UNIDIR)/UnicodeData.txt $(UNIDIR)/SpecialCasing.txt tools/makeUnicodeDigits.py tools/unicode_table.py | $(GENDIR)
+	$(PYTHON) ./tools/makeUnicodeDigits.py $(UNIDIR)/UnicodeData.txt $(UNIDIR)/SpecialCasing.txt > $@
+
+$(GENDIR)/UnicodeCasing.inc: $(UNIDIR)/UnicodeData.txt $(UNIDIR)/SpecialCasing.txt tools/makeUnicodeCasing.py tools/unicode_table.py | $(GENDIR)
+	$(PYTHON) ./tools/makeUnicodeCasing.py $(UNIDIR)/UnicodeData.txt $(UNIDIR)/SpecialCasing.txt > $@
+
+$(GENDIR)/UnicodeNumbers.inc: $(UNIDIR)/UnicodeData.txt $(UNIDIR)/SpecialCasing.txt tools/makeUnicodeNumbers.py tools/unicode_table.py | $(GENDIR)
+	$(PYTHON) ./tools/makeUnicodeNumbers.py $(UNIDIR)/UnicodeData.txt $(UNIDIR)/SpecialCasing.txt > $@
 
 realclean: clean
 	rm -rf tags xref $(UNIDIR)

--- a/src/builtins_helper.c
+++ b/src/builtins_helper.c
@@ -50,6 +50,10 @@ static void registerIsUpper(BuiltIns *registry);
 static void registerIsValid(BuiltIns *registry);
 static void registerIsXdigit(BuiltIns *registry);
 static void registerGetDec(BuiltIns *registry);
+static void registerToUpper(BuiltIns *registry);
+static void registerToLower(BuiltIns *registry);
+static void registerToTitle(BuiltIns *registry);
+static void registerGetNum(BuiltIns *registry);
 static void registerChr(BuiltIns *registry);
 static void registerArgv(BuiltIns *registry, int argc, int cargc, char *argv[]);
 static void registerGetEnv(BuiltIns *registry);
@@ -182,6 +186,10 @@ BuiltIns *registerBuiltIns(int argc, int cargc, char *argv[]) {
     registerIsValid(res);
     registerIsXdigit(res);
     registerGetDec(res);
+    registerToUpper(res);
+    registerToLower(res);
+    registerToTitle(res);
+    registerGetNum(res);
     registerChr(res);
     registerIO(res);
     registerSQLite(res);
@@ -538,5 +546,51 @@ static void registerGetDec(BuiltIns *registry) {
     pushCharacterArg(args);
     pushNewBuiltIn(registry, "getdec", integer, args, (void *)builtin_getdec,
                    "builtin_getdec");
+    UNPROTECT(save);
+}
+
+static void registerToUpper(BuiltIns *registry) {
+    BuiltInArgs *args = newBuiltInArgs();
+    int save = PROTECT(args);
+    TcType *string = makeStringType();
+    PROTECT(string);
+    pushCharacterArg(args);
+    pushNewBuiltIn(registry, "toupper", string, args, (void *)builtin_toupper,
+                   "builtin_toupper");
+    UNPROTECT(save);
+}
+
+static void registerToLower(BuiltIns *registry) {
+    BuiltInArgs *args = newBuiltInArgs();
+    int save = PROTECT(args);
+    TcType *string = makeStringType();
+    PROTECT(string);
+    pushCharacterArg(args);
+    pushNewBuiltIn(registry, "tolower", string, args, (void *)builtin_tolower,
+                   "builtin_tolower");
+    UNPROTECT(save);
+}
+
+static void registerToTitle(BuiltIns *registry) {
+    BuiltInArgs *args = newBuiltInArgs();
+    int save = PROTECT(args);
+    TcType *string = makeStringType();
+    PROTECT(string);
+    pushCharacterArg(args);
+    pushNewBuiltIn(registry, "totitle", string, args, (void *)builtin_totitle,
+                   "builtin_totitle");
+    UNPROTECT(save);
+}
+
+static void registerGetNum(BuiltIns *registry) {
+    BuiltInArgs *args = newBuiltInArgs();
+    int save = PROTECT(args);
+    TcType *numberType = makeTypeSig(newSymbol("number"), NULL);
+    PROTECT(numberType);
+    TcType *maybeNumberType = makeMaybeType(numberType);
+    PROTECT(maybeNumberType);
+    pushCharacterArg(args);
+    pushNewBuiltIn(registry, "getnum", maybeNumberType, args,
+                   (void *)builtin_getnum, "builtin_getnum");
     UNPROTECT(save);
 }

--- a/src/builtins_impl.c
+++ b/src/builtins_impl.c
@@ -21,6 +21,61 @@
 #include "builtins_helper.h"
 #include "unicode.h"
 #include <stdlib.h>
+#include <string.h>
+
+static Value characterSequenceToList(const Character *chars, Index length) {
+    Value list = makeEmptyList();
+    int save = protectValue(list);
+
+    for (Index i = length; i > 0; i--) {
+        list = makePair(value_Character(chars[i - 1]), list);
+        protectValue(list);
+    }
+
+    UNPROTECT(save);
+    return list;
+}
+
+static Value unicodeCaseToList(Character c,
+                               Index (*mapping)(Character, Character *,
+                                                Index)) {
+    CharacterArray *chars = newCharacterArray();
+    int save = PROTECT(chars);
+    Index length = mapping(c, NULL, 0);
+
+    extendCharacterArray(chars, length + 1);
+    chars->size = length + 1;
+    if (length > 0) {
+        mapping(c, chars->entries, length);
+    }
+    chars->entries[length] = (Character)0;
+
+    Value result = characterSequenceToList(chars->entries, length);
+    protectValue(result);
+    UNPROTECT(save);
+    return result;
+}
+
+static Value parseUnicodeFraction(const char *fraction) {
+    const char *slash = strchr(fraction, '/');
+    Value numerator;
+    Value denominator;
+    Value result;
+    int save;
+
+    if (slash == NULL) {
+        cant_happen("malformed Unicode fraction %s", fraction);
+    }
+
+    numerator = value_Stdint((int)strtol(fraction, NULL, 10));
+    denominator = value_Stdint((int)strtol(slash + 1, NULL, 10));
+    save = protectValue(numerator);
+    protectValue(denominator);
+    result = ndiv(numerator, denominator);
+    protectValue(result);
+    UNPROTECT(save);
+    return result;
+}
 
 bool assertions_failed;
 int assertions_accumulate = 0;
@@ -156,6 +211,45 @@ Value builtin_unicode_category(Vec *args) {
 
 Value builtin_getdec(Vec *args) {
     return value_Stdint(unicode_getdec(args->entries[0].val.character));
+}
+
+Value builtin_toupper(Vec *args) {
+    return unicodeCaseToList(args->entries[0].val.character, unicode_toupper);
+}
+
+Value builtin_tolower(Vec *args) {
+    return unicodeCaseToList(args->entries[0].val.character, unicode_tolower);
+}
+
+Value builtin_totitle(Vec *args) {
+    return unicodeCaseToList(args->entries[0].val.character, unicode_totitle);
+}
+
+Value builtin_getnum(Vec *args) {
+    UnicodeNumericValue numeric;
+    Value number;
+    Value result;
+    int save;
+
+    if (!unicode_getnum(args->entries[0].val.character, &numeric)) {
+        return makeNothing();
+    }
+
+    if (numeric.hasIntegerValue) {
+        number = value_Stdint((int)numeric.integerValue);
+    } else if (numeric.fractionValue != NULL) {
+        number = parseUnicodeFraction(numeric.fractionValue);
+    } else if (numeric.hasDecimalValue) {
+        number = value_Stdint(numeric.decimalValue);
+    } else {
+        return makeNothing();
+    }
+
+    save = protectValue(number);
+    result = makeSome(number);
+    protectValue(result);
+    UNPROTECT(save);
+    return result;
 }
 
 Value builtin_isalnum(Vec *args) {

--- a/src/builtins_impl.h
+++ b/src/builtins_impl.h
@@ -54,6 +54,10 @@ Value builtin_isupper(Vec *args);
 Value builtin_isvalid(Vec *args);
 Value builtin_isxdigit(Vec *args);
 Value builtin_getdec(Vec *args);
+Value builtin_toupper(Vec *args);
+Value builtin_tolower(Vec *args);
+Value builtin_totitle(Vec *args);
+Value builtin_getnum(Vec *args);
 void builtin_exit(Vec *args);
 
 extern int builtin_args_argc;

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -23,97 +23,286 @@
 // to be a control character and not a space) the ctype.h result is
 // preferred.
 
-#include <ctype.h>
 #include "unicode.h"
-#include "common.h"
-#include "UnicodeDigits.inc"
-
-static unsigned char category[] = {
+#include "UnicodeCasing.inc"
+#include "UnicodeNumbers.inc"
 #include "UnicodeData.inc"
-};
+#include "UnicodeDigits.inc"
+#include "common.h"
+#include <ctype.h>
+#include <stdint.h>
 
-__attribute__((unused)) static inline bool isGC_L(Character c) { return (category[c] & GC_MASK) == GC_L; }
-__attribute__((unused)) static inline bool isGC_M(Character c) { return (category[c] & GC_MASK) == GC_M; }
-__attribute__((unused)) static inline bool isGC_N(Character c) { return (category[c] & GC_MASK) == GC_N; }
-__attribute__((unused)) static inline bool isGC_P(Character c) { return (category[c] & GC_MASK) == GC_P; }
-__attribute__((unused)) static inline bool isGC_S(Character c) { return (category[c] & GC_MASK) == GC_S; }
-__attribute__((unused)) static inline bool isGC_Z(Character c) { return (category[c] & GC_MASK) == GC_Z; }
-__attribute__((unused)) static inline bool isGC_C(Character c) { return (category[c] & GC_MASK) == GC_C; }
+static inline unsigned char categoryAt(Character c) {
+    uint32_t code = (uint32_t)c;
+    return unicodeCategoryPages[unicodeCategoryPageIndex[code >> 8]]
+                               [code & 0xFF];
+}
 
-__attribute__((unused)) static inline bool isGC_Ll(Character c) { return category[c] == GC_Ll; }
-__attribute__((unused)) static inline bool isGC_Lm(Character c) { return category[c] == GC_Lm; }
-__attribute__((unused)) static inline bool isGC_Lo(Character c) { return category[c] == GC_Lo; }
-__attribute__((unused)) static inline bool isGC_Lt(Character c) { return category[c] == GC_Lt; }
-__attribute__((unused)) static inline bool isGC_Lu(Character c) { return category[c] == GC_Lu; }
-__attribute__((unused)) static inline bool isGC_Mc(Character c) { return category[c] == GC_Mc; }
-__attribute__((unused)) static inline bool isGC_Me(Character c) { return category[c] == GC_Me; }
-__attribute__((unused)) static inline bool isGC_Mn(Character c) { return category[c] == GC_Mn; }
-__attribute__((unused)) static inline bool isGC_Nd(Character c) { return category[c] == GC_Nd; }
-__attribute__((unused)) static inline bool isGC_Nl(Character c) { return category[c] == GC_Nl; }
-__attribute__((unused)) static inline bool isGC_No(Character c) { return category[c] == GC_No; }
-__attribute__((unused)) static inline bool isGC_Pc(Character c) { return category[c] == GC_Pc; }
-__attribute__((unused)) static inline bool isGC_Pd(Character c) { return category[c] == GC_Pd; }
-__attribute__((unused)) static inline bool isGC_Pe(Character c) { return category[c] == GC_Pe; }
-__attribute__((unused)) static inline bool isGC_Pf(Character c) { return category[c] == GC_Pf; }
-__attribute__((unused)) static inline bool isGC_Pi(Character c) { return category[c] == GC_Pi; }
-__attribute__((unused)) static inline bool isGC_Po(Character c) { return category[c] == GC_Po; }
-__attribute__((unused)) static inline bool isGC_Ps(Character c) { return category[c] == GC_Ps; }
-__attribute__((unused)) static inline bool isGC_Sc(Character c) { return category[c] == GC_Sc; }
-__attribute__((unused)) static inline bool isGC_Sk(Character c) { return category[c] == GC_Sk; }
-__attribute__((unused)) static inline bool isGC_Sm(Character c) { return category[c] == GC_Sm; }
-__attribute__((unused)) static inline bool isGC_So(Character c) { return category[c] == GC_So; }
-__attribute__((unused)) static inline bool isGC_Zl(Character c) { return category[c] == GC_Zl; }
-__attribute__((unused)) static inline bool isGC_Zp(Character c) { return category[c] == GC_Zp; }
-__attribute__((unused)) static inline bool isGC_Zs(Character c) { return category[c] == GC_Zs; }
-__attribute__((unused)) static inline bool isGC_Cc(Character c) { return category[c] == GC_Cc; }
-__attribute__((unused)) static inline bool isGC_Cf(Character c) { return category[c] == GC_Cf; }
-__attribute__((unused)) static inline bool isGC_Co(Character c) { return category[c] == GC_Co; }
-__attribute__((unused)) static inline bool isGC_Cs(Character c) { return category[c] == GC_Cs; }
-__attribute__((unused)) static inline bool isGC_Cn(Character c) { return category[c] == GC_Cn; }
+static const UnicodeCaseEntry *findCaseEntry(Character c) {
+    uint32_t code = (uint32_t)c;
+    uint32_t low = 0;
+    uint32_t high = unicodeCaseEntryCount;
 
-int unicode_getdec(Character c) {
-    switch (c) {
-        UNICODE_DIGITS_CASES
+    while (low < high) {
+        uint32_t mid = low + (high - low) / 2;
+        const UnicodeCaseEntry *entry = &unicodeCaseEntries[mid];
+
+        if (entry->code == code) {
+            return entry;
+        }
+
+        if (entry->code < code) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+
+    return NULL;
+}
+
+static const UnicodeNumberEntry *findNumberEntry(Character c) {
+    uint32_t code = (uint32_t)c;
+    uint32_t low = 0;
+    uint32_t high = unicodeNumberEntryCount;
+
+    while (low < high) {
+        uint32_t mid = low + (high - low) / 2;
+        const UnicodeNumberEntry *entry = &unicodeNumberEntries[mid];
+
+        if (entry->code == code) {
+            return entry;
+        }
+
+        if (entry->code < code) {
+            low = mid + 1;
+        } else {
+            high = mid;
+        }
+    }
+
+    return NULL;
+}
+
+static Index copyCaseMapping(Character c, int32_t delta, uint32_t specialOffset,
+                             Character *buffer, Index bufferSize) {
+    if (specialOffset != 0) {
+        uint32_t length = unicodeSpecialCaseData[specialOffset];
+
+        for (uint32_t i = 0; i < length && i < bufferSize; i++) {
+            buffer[i] =
+                (Character)unicodeSpecialCaseData[specialOffset + 1 + i];
+        }
+
+        return (Index)length;
+    }
+
+    if (bufferSize > 0) {
+        buffer[0] = delta == 0 ? c : c + delta;
+    }
+
+    return 1;
+}
+
+static Index unicodeCaseMap(Character c, Character *buffer, Index bufferSize,
+                            int whichCase) {
+    const UnicodeCaseEntry *entry = findCaseEntry(c);
+
+    if (entry == NULL) {
+        if (bufferSize > 0) {
+            buffer[0] = c;
+        }
+
+        return 1;
+    }
+
+    switch (whichCase) {
+    case 0:
+        return copyCaseMapping(c, entry->upperDelta, entry->upperSpecial,
+                               buffer, bufferSize);
+    case 1:
+        return copyCaseMapping(c, entry->lowerDelta, entry->lowerSpecial,
+                               buffer, bufferSize);
+    case 2:
+        return copyCaseMapping(c, entry->titleDelta, entry->titleSpecial,
+                               buffer, bufferSize);
+    default:
+        cant_happen("invalid Unicode case index %d", whichCase);
     }
 }
 
-bool unicode_isvalid(Character c) {
-    return c >= 0 && c <= UNICODE_MAX;
+__attribute__((unused)) static inline bool isGC_L(Character c) {
+    return (categoryAt(c) & GC_MASK) == GC_L;
 }
+__attribute__((unused)) static inline bool isGC_M(Character c) {
+    return (categoryAt(c) & GC_MASK) == GC_M;
+}
+__attribute__((unused)) static inline bool isGC_N(Character c) {
+    return (categoryAt(c) & GC_MASK) == GC_N;
+}
+__attribute__((unused)) static inline bool isGC_P(Character c) {
+    return (categoryAt(c) & GC_MASK) == GC_P;
+}
+__attribute__((unused)) static inline bool isGC_S(Character c) {
+    return (categoryAt(c) & GC_MASK) == GC_S;
+}
+__attribute__((unused)) static inline bool isGC_Z(Character c) {
+    return (categoryAt(c) & GC_MASK) == GC_Z;
+}
+__attribute__((unused)) static inline bool isGC_C(Character c) {
+    return (categoryAt(c) & GC_MASK) == GC_C;
+}
+
+__attribute__((unused)) static inline bool isGC_Ll(Character c) {
+    return categoryAt(c) == GC_Ll;
+}
+__attribute__((unused)) static inline bool isGC_Lm(Character c) {
+    return categoryAt(c) == GC_Lm;
+}
+__attribute__((unused)) static inline bool isGC_Lo(Character c) {
+    return categoryAt(c) == GC_Lo;
+}
+__attribute__((unused)) static inline bool isGC_Lt(Character c) {
+    return categoryAt(c) == GC_Lt;
+}
+__attribute__((unused)) static inline bool isGC_Lu(Character c) {
+    return categoryAt(c) == GC_Lu;
+}
+__attribute__((unused)) static inline bool isGC_Mc(Character c) {
+    return categoryAt(c) == GC_Mc;
+}
+__attribute__((unused)) static inline bool isGC_Me(Character c) {
+    return categoryAt(c) == GC_Me;
+}
+__attribute__((unused)) static inline bool isGC_Mn(Character c) {
+    return categoryAt(c) == GC_Mn;
+}
+__attribute__((unused)) static inline bool isGC_Nd(Character c) {
+    return categoryAt(c) == GC_Nd;
+}
+__attribute__((unused)) static inline bool isGC_Nl(Character c) {
+    return categoryAt(c) == GC_Nl;
+}
+__attribute__((unused)) static inline bool isGC_No(Character c) {
+    return categoryAt(c) == GC_No;
+}
+__attribute__((unused)) static inline bool isGC_Pc(Character c) {
+    return categoryAt(c) == GC_Pc;
+}
+__attribute__((unused)) static inline bool isGC_Pd(Character c) {
+    return categoryAt(c) == GC_Pd;
+}
+__attribute__((unused)) static inline bool isGC_Pe(Character c) {
+    return categoryAt(c) == GC_Pe;
+}
+__attribute__((unused)) static inline bool isGC_Pf(Character c) {
+    return categoryAt(c) == GC_Pf;
+}
+__attribute__((unused)) static inline bool isGC_Pi(Character c) {
+    return categoryAt(c) == GC_Pi;
+}
+__attribute__((unused)) static inline bool isGC_Po(Character c) {
+    return categoryAt(c) == GC_Po;
+}
+__attribute__((unused)) static inline bool isGC_Ps(Character c) {
+    return categoryAt(c) == GC_Ps;
+}
+__attribute__((unused)) static inline bool isGC_Sc(Character c) {
+    return categoryAt(c) == GC_Sc;
+}
+__attribute__((unused)) static inline bool isGC_Sk(Character c) {
+    return categoryAt(c) == GC_Sk;
+}
+__attribute__((unused)) static inline bool isGC_Sm(Character c) {
+    return categoryAt(c) == GC_Sm;
+}
+__attribute__((unused)) static inline bool isGC_So(Character c) {
+    return categoryAt(c) == GC_So;
+}
+__attribute__((unused)) static inline bool isGC_Zl(Character c) {
+    return categoryAt(c) == GC_Zl;
+}
+__attribute__((unused)) static inline bool isGC_Zp(Character c) {
+    return categoryAt(c) == GC_Zp;
+}
+__attribute__((unused)) static inline bool isGC_Zs(Character c) {
+    return categoryAt(c) == GC_Zs;
+}
+__attribute__((unused)) static inline bool isGC_Cc(Character c) {
+    return categoryAt(c) == GC_Cc;
+}
+__attribute__((unused)) static inline bool isGC_Cf(Character c) {
+    return categoryAt(c) == GC_Cf;
+}
+__attribute__((unused)) static inline bool isGC_Co(Character c) {
+    return categoryAt(c) == GC_Co;
+}
+__attribute__((unused)) static inline bool isGC_Cs(Character c) {
+    return categoryAt(c) == GC_Cs;
+}
+__attribute__((unused)) static inline bool isGC_Cn(Character c) {
+    return categoryAt(c) == GC_Cn;
+}
+
+int unicode_getdec(Character c) {
+    switch (c) { UNICODE_DIGITS_CASES }
+}
+
+Index unicode_toupper(Character c, Character *buffer, Index bufferSize) {
+    return unicode_isvalid(c) ? unicodeCaseMap(c, buffer, bufferSize, 0) : 0;
+}
+
+Index unicode_tolower(Character c, Character *buffer, Index bufferSize) {
+    return unicode_isvalid(c) ? unicodeCaseMap(c, buffer, bufferSize, 1) : 0;
+}
+
+Index unicode_totitle(Character c, Character *buffer, Index bufferSize) {
+    return unicode_isvalid(c) ? unicodeCaseMap(c, buffer, bufferSize, 2) : 0;
+}
+
+bool unicode_getnum(Character c, UnicodeNumericValue *out) {
+    const UnicodeNumberEntry *entry;
+
+    if (!unicode_isvalid(c) || out == NULL) {
+        return false;
+    }
+
+    entry = findNumberEntry(c);
+    if (entry == NULL) {
+        return false;
+    }
+
+    out->hasDecimalValue = entry->decimalValue >= 0;
+    out->decimalValue = entry->decimalValue;
+    out->hasIntegerValue = entry->hasIntegerValue != 0;
+    out->integerValue = entry->integerValue;
+    out->fractionValue = entry->fractionValue;
+    return true;
+}
+
+bool unicode_isvalid(Character c) { return c >= 0 && c <= UNICODE_MAX; }
 
 static inline bool isValid(Character c) { return c >= 0 && c <= UNICODE_MAX; }
 
-bool unicode_isascii(Character c) {
-    return c >= 0 && c < 0x80;
-}
+bool unicode_isascii(Character c) { return c >= 0 && c < 0x80; }
 
-bool unicode_isopen(Character c) {
-    return isValid(c) && isGC_Ps(c);
-}
+bool unicode_isopen(Character c) { return isValid(c) && isGC_Ps(c); }
 
-bool unicode_isclose(Character c) {
-    return isValid(c) && isGC_Pe(c);
-}
+bool unicode_isclose(Character c) { return isValid(c) && isGC_Pe(c); }
 
-bool unicode_issymbol(Character c) {
-    return isValid(c) && isGC_S(c);
-}
+bool unicode_issymbol(Character c) { return isValid(c) && isGC_S(c); }
 
 bool unicode_isalpha(Character c) {
     return isValid(c) && (isGC_L(c) || c == '_');
 }
 
-bool unicode_ismark(Character c) {
-    return isValid(c) && isGC_M(c);
-}
+bool unicode_ismark(Character c) { return isValid(c) && isGC_M(c); }
 
-bool unicode_isnumber(Character c) {
-    return isValid(c) && isGC_N(c);
-}
+bool unicode_isnumber(Character c) { return isValid(c) && isGC_N(c); }
 
 bool unicode_isgraph(Character c) {
-    return isValid(c) &&
-           ((unicode_isascii(c) && isgraph(c)) || isGC_C(c) || isGC_Zl(c) || isGC_Zp(c));
+    return isValid(c) && ((unicode_isascii(c) && isgraph(c)) || isGC_C(c) ||
+                          isGC_Zl(c) || isGC_Zp(c));
 }
 
 bool unicode_isalnum(Character c) {
@@ -124,13 +313,9 @@ bool unicode_iscntrl(Character c) {
     return isValid(c) && ((unicode_isascii(c) && iscntrl(c)) || isGC_Cc(c));
 }
 
-bool unicode_isdigit(Character c) {
-    return isValid(c) && isGC_Nd(c);
-}
+bool unicode_isdigit(Character c) { return isValid(c) && isGC_Nd(c); }
 
-bool unicode_islower(Character c) {
-    return isValid(c) && isGC_Ll(c);
-}
+bool unicode_islower(Character c) { return isValid(c) && isGC_Ll(c); }
 
 bool unicode_isprint(Character c) {
     return unicode_isalnum(c) || unicode_isspace(c) || unicode_ispunct(c);
@@ -138,8 +323,7 @@ bool unicode_isprint(Character c) {
 
 bool unicode_ispunct(Character c) {
     return isValid(c) &&
-           ((unicode_isascii(c) && ispunct(c)) ||
-            (isGC_P(c) && !isGC_Pc(c)));
+           ((unicode_isascii(c) && ispunct(c)) || (isGC_P(c) && !isGC_Pc(c)));
 }
 
 bool unicode_isspace(Character c) {
@@ -154,10 +338,6 @@ bool unicode_isblank(Character c) {
     return isValid(c) && ((unicode_isascii(c) && isblank(c)) || isGC_Zs(c));
 }
 
-bool unicode_isxdigit(Character c) {
-    return unicode_isascii(c) && isxdigit(c);
-}
+bool unicode_isxdigit(Character c) { return unicode_isascii(c) && isxdigit(c); }
 
-int unicode_category(Character c) {
-    return isValid(c) ? category[c] : GC_Cn;
-}
+int unicode_category(Character c) { return isValid(c) ? categoryAt(c) : GC_Cn; }

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -1,74 +1,83 @@
 #ifndef cekf_unicode_h
-#  define cekf_unicode_h
+#define cekf_unicode_h
 /*
  * CEKF - VM supporting amb
  * Copyright (C) 2022-2024  Bill Hails
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include <stdbool.h>
 #include "types.h"
+#include <stdbool.h>
+#include <stdint.h>
 
 #define UNICODE_MAX 0x10FFFD
 
 #define GC_MASK 0x07
 
-#define GC_L    0x00
-#define GC_M    0x01
-#define GC_N    0x02
-#define GC_P    0x03
-#define GC_S    0x04
-#define GC_Z    0x05
-#define GC_C    0x06
+#define GC_L 0x00
+#define GC_M 0x01
+#define GC_N 0x02
+#define GC_P 0x03
+#define GC_S 0x04
+#define GC_Z 0x05
+#define GC_C 0x06
 
-#define GC_Ll   (GC_L | (0x00 << 3))
-#define GC_Lm   (GC_L | (0x01 << 3))
-#define GC_Lo   (GC_L | (0x02 << 3))
-#define GC_Lt   (GC_L | (0x03 << 3))
-#define GC_Lu   (GC_L | (0x04 << 3))
+#define GC_Ll (GC_L | (0x00 << 3))
+#define GC_Lm (GC_L | (0x01 << 3))
+#define GC_Lo (GC_L | (0x02 << 3))
+#define GC_Lt (GC_L | (0x03 << 3))
+#define GC_Lu (GC_L | (0x04 << 3))
 
-#define GC_Mc   (GC_M | (0x00 << 3))
-#define GC_Me   (GC_M | (0x01 << 3))
-#define GC_Mn   (GC_M | (0x02 << 3))
+#define GC_Mc (GC_M | (0x00 << 3))
+#define GC_Me (GC_M | (0x01 << 3))
+#define GC_Mn (GC_M | (0x02 << 3))
 
-#define GC_Nd   (GC_N | (0x00 << 3))
-#define GC_Nl   (GC_N | (0x01 << 3))
-#define GC_No   (GC_N | (0x02 << 3))
+#define GC_Nd (GC_N | (0x00 << 3))
+#define GC_Nl (GC_N | (0x01 << 3))
+#define GC_No (GC_N | (0x02 << 3))
 
-#define GC_Pc   (GC_P | (0x00 << 3))
-#define GC_Pd   (GC_P | (0x01 << 3))
-#define GC_Pe   (GC_P | (0x02 << 3))
-#define GC_Pf   (GC_P | (0x03 << 3))
-#define GC_Pi   (GC_P | (0x04 << 3))
-#define GC_Po   (GC_P | (0x05 << 3))
-#define GC_Ps   (GC_P | (0x06 << 3))
+#define GC_Pc (GC_P | (0x00 << 3))
+#define GC_Pd (GC_P | (0x01 << 3))
+#define GC_Pe (GC_P | (0x02 << 3))
+#define GC_Pf (GC_P | (0x03 << 3))
+#define GC_Pi (GC_P | (0x04 << 3))
+#define GC_Po (GC_P | (0x05 << 3))
+#define GC_Ps (GC_P | (0x06 << 3))
 
-#define GC_Sc   (GC_S | (0x00 << 3))
-#define GC_Sk   (GC_S | (0x01 << 3))
-#define GC_Sm   (GC_S | (0x02 << 3))
-#define GC_So   (GC_S | (0x03 << 3))
+#define GC_Sc (GC_S | (0x00 << 3))
+#define GC_Sk (GC_S | (0x01 << 3))
+#define GC_Sm (GC_S | (0x02 << 3))
+#define GC_So (GC_S | (0x03 << 3))
 
-#define GC_Zl   (GC_Z | (0x00 << 3))
-#define GC_Zp   (GC_Z | (0x01 << 3))
-#define GC_Zs   (GC_Z | (0x02 << 3))
+#define GC_Zl (GC_Z | (0x00 << 3))
+#define GC_Zp (GC_Z | (0x01 << 3))
+#define GC_Zs (GC_Z | (0x02 << 3))
 
-#define GC_Cc   (GC_C | (0x00 << 3))
-#define GC_Cf   (GC_C | (0x01 << 3))
-#define GC_Co   (GC_C | (0x02 << 3))
-#define GC_Cs   (GC_C | (0x03 << 3))
-#define GC_Cn   (GC_C | (0x04 << 3))
+#define GC_Cc (GC_C | (0x00 << 3))
+#define GC_Cf (GC_C | (0x01 << 3))
+#define GC_Co (GC_C | (0x02 << 3))
+#define GC_Cs (GC_C | (0x03 << 3))
+#define GC_Cn (GC_C | (0x04 << 3))
+
+typedef struct {
+    bool hasDecimalValue;
+    int decimalValue;
+    bool hasIntegerValue;
+    int64_t integerValue;
+    const char *fractionValue;
+} UnicodeNumericValue;
 
 bool unicode_isalnum(Character c);
 bool unicode_isalpha(Character c);
@@ -80,7 +89,8 @@ bool unicode_isdigit(Character c);
 bool unicode_isgraph(Character c);
 bool unicode_islower(Character c);
 bool unicode_ismark(Character c);
-bool unicode_isnumber(Character c); // includes digits, roman numerals, vulgar fractions etc.
+bool unicode_isnumber(
+    Character c); // includes digits, roman numerals, vulgar fractions etc.
 bool unicode_isopen(Character c);
 bool unicode_isprint(Character c);
 bool unicode_ispunct(Character c);
@@ -92,5 +102,9 @@ bool unicode_isxdigit(Character c);
 
 int unicode_category(Character c);
 int unicode_getdec(Character c);
+Index unicode_toupper(Character c, Character *buffer, Index bufferSize);
+Index unicode_tolower(Character c, Character *buffer, Index bufferSize);
+Index unicode_totitle(Character c, Character *buffer, Index bufferSize);
+bool unicode_getnum(Character c, UnicodeNumericValue *out);
 
 #endif

--- a/tests/fn/test_builtin_unicode.fn
+++ b/tests/fn/test_builtin_unicode.fn
@@ -1,3 +1,6 @@
+let
+	link "ioutils.fn" as io;
+in
 assert(unicode_category('A') == GC_Lu);
 assert(unicode_category('z') == GC_Ll);
 assert(unicode_category('ǅ') == GC_Lt);
@@ -46,5 +49,28 @@ assert(unicode_category('\u200E;') == GC_Cf); // Left-To-Right Mark
 // so we use a code point from the Private Use Area
 assert(unicode_category('\uE000;') == GC_Co); // Private Use Area
 assert(unicode_category('\uD800;') == GC_Cs); // High Surrogate
-// GC_Cn (Unassigned) test - using a code point that is currently unassigned
-assert(unicode_category('\u0378;') == GC_Ll); // Lowecase letter
+assert(getdec('\u0667;') == 7); // Arabic-Indic digit seven
+assert(toupper('a') == "A");
+assert(tolower('A') == "a");
+assert(totitle('ǆ') == "ǅ");
+assert(toupper('ß') == "SS");
+assert(tolower('İ') == "i\u0307;");
+switch(getnum('Ⅶ')) {
+	(just(n)) { assert(io.to_string(n) == "7") }
+	(nothing) { assert(false) }
+}
+switch(getnum('½')) {
+	(just(n)) { assert(io.to_string(n) == "1/2") }
+	(nothing) { assert(false) }
+}
+switch(getnum('५')) {
+	(just(n)) { assert(io.to_string(n) == "5") }
+	(nothing) { assert(false) }
+}
+// GC_Cn (Unassigned) test - U+0378 is an unassigned code point
+assert(unicode_category('\u0378;') == GC_Cn);
+assert(getdec('\u0378;') == -1);
+switch(getnum('\u0378;')) {
+	(nothing) { assert(true) }
+	(just(_)) { assert(false) }
+}

--- a/tests/fn/test_unicode.fn
+++ b/tests/fn/test_unicode.fn
@@ -1,5 +1,6 @@
 let
     link "listutils.fn" as list;
+    link "ioutils.fn" as io;
 
     fn test_unicode_basic() {
         let
@@ -135,6 +136,17 @@ let
         // Superscripts and subscripts
         assert(isnumber('²')); // superscript two
         assert(isnumber('₃')); // subscript three
+        switch(getnum('Ⅶ')) {
+            (just(n)) { assert(io.to_string(n) == "7") }
+            (nothing) { assert(false) }
+        }
+        switch(getnum('½')) {
+            (just(n)) { assert(io.to_string(n) == "1/2") }
+            (nothing) { assert(false) }
+        }
+        assert(toupper('ß') == "SS"); // multi-code-point uppercase expansion
+        assert(tolower('İ') == "i\u0307;"); // lowercase expansion with combining mark
+        assert(totitle('ǆ') == "ǅ"); // titlecase mapping
         // Spaces of various widths
         assert(isspace('\u00a0;')); // non-breaking space
         assert(isspace('\u3000;')); // ideographic space

--- a/tests/fn/test_unicode_extended.fn
+++ b/tests/fn/test_unicode_extended.fn
@@ -1,5 +1,6 @@
 let
     link "listutils.fn" as list;
+    link "ioutils.fn" as io;
     Σ = "abc\u03b1;\u03b2;\u03b3;";
     Ψ = "abcαβγ";
     α = '\u03b1;';
@@ -129,6 +130,17 @@ in
     assert(getdec('５') == 5); // Fullwidth digit five
     assert(getdec('९') == 9); // Devanagari digit nine
     assert(getdec('٧') == 7); // Arabic-Indic digit seven
+    switch(getnum('Ⅶ')) {
+        (just(n)) { assert(io.to_string(n) == "7") }
+        (nothing) { assert(false) }
+    }
+    switch(getnum('½')) {
+        (just(n)) { assert(io.to_string(n) == "1/2") }
+        (nothing) { assert(false) }
+    }
+    assert(toupper('ß') == "SS"); // multi-code-point uppercase expansion
+    assert(tolower('İ') == "i\u0307;"); // lowercase expansion with combining mark
+    assert(totitle('ǆ') == "ǅ"); // titlecase mapping
     // Spaces of various widths
     assert(isspace('\u00a0;')); // non-breaking space
     assert(isspace('\u3000;')); // ideographic space

--- a/tools/makeUnicodeCasing.py
+++ b/tools/makeUnicodeCasing.py
@@ -4,4 +4,4 @@ from unicode_table import main
 
 
 if __name__ == "__main__":
-    main("digits")
+    main("casing")

--- a/tools/makeUnicodeData.py
+++ b/tools/makeUnicodeData.py
@@ -1,23 +1,7 @@
-# generate a full category table for all Unicode code points
-import csv
+#!/usr/bin/env python3
 
-with open('unicode/UnicodeData.txt', newline='') as csvin:
-    reader = csv.reader(csvin, delimiter=';')
-    i = 0
-    prev = 'GC_Co'
-    print('/* 000000 */ ', end='')
-    for row in reader:
-        j = int(row[0], 16)
-        while i < j:
-            if i > 0 and i % 16 == 0:
-                print('')
-                print('/* {:06X} */ '.format(i), end='')
-            print(f"{prev}, ", end='')
-            i += 1
-        i += 1
-        if j > 0 and j % 16 == 0:
-            print('')
-            print('/* {:06X} */ '.format(j), end='')
-        prev = f"GC_{row[2]}"
-        print(f"{prev}, ", end='')
-    print('')
+from unicode_table import main
+
+
+if __name__ == "__main__":
+    main("categories")

--- a/tools/makeUnicodeNumbers.py
+++ b/tools/makeUnicodeNumbers.py
@@ -4,4 +4,4 @@ from unicode_table import main
 
 
 if __name__ == "__main__":
-    main("digits")
+    main("numbers")

--- a/tools/unicode_table.py
+++ b/tools/unicode_table.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+#
+# CEKF - VM supporting amb
+# Copyright (C) 2022-2024  Bill Hails
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import argparse
+import csv
+from dataclasses import dataclass
+
+UNICODE_TABLE_SIZE = 0x110000
+PAGE_BITS = 8
+PAGE_SIZE = 1 << PAGE_BITS
+PAGE_COUNT = UNICODE_TABLE_SIZE >> PAGE_BITS
+
+GC_L = 0x00
+GC_M = 0x01
+GC_N = 0x02
+GC_P = 0x03
+GC_S = 0x04
+GC_Z = 0x05
+GC_C = 0x06
+
+
+def gc(base, ordinal):
+    return base | (ordinal << 3)
+
+
+CATEGORY_VALUES = {
+    "Ll": gc(GC_L, 0),
+    "Lm": gc(GC_L, 1),
+    "Lo": gc(GC_L, 2),
+    "Lt": gc(GC_L, 3),
+    "Lu": gc(GC_L, 4),
+    "Mc": gc(GC_M, 0),
+    "Me": gc(GC_M, 1),
+    "Mn": gc(GC_M, 2),
+    "Nd": gc(GC_N, 0),
+    "Nl": gc(GC_N, 1),
+    "No": gc(GC_N, 2),
+    "Pc": gc(GC_P, 0),
+    "Pd": gc(GC_P, 1),
+    "Pe": gc(GC_P, 2),
+    "Pf": gc(GC_P, 3),
+    "Pi": gc(GC_P, 4),
+    "Po": gc(GC_P, 5),
+    "Ps": gc(GC_P, 6),
+    "Sc": gc(GC_S, 0),
+    "Sk": gc(GC_S, 1),
+    "Sm": gc(GC_S, 2),
+    "So": gc(GC_S, 3),
+    "Zl": gc(GC_Z, 0),
+    "Zp": gc(GC_Z, 1),
+    "Zs": gc(GC_Z, 2),
+    "Cc": gc(GC_C, 0),
+    "Cf": gc(GC_C, 1),
+    "Co": gc(GC_C, 2),
+    "Cs": gc(GC_C, 3),
+    "Cn": gc(GC_C, 4),
+}
+DEFAULT_CATEGORY = CATEGORY_VALUES["Cn"]
+CATEGORY_NAMES = {value: f"GC_{key}" for key, value in CATEGORY_VALUES.items()}
+
+
+@dataclass(frozen=True)
+class SpecialCasing:
+    lower: tuple
+    title: tuple
+    upper: tuple
+
+
+@dataclass
+class UnicodeTables:
+    categories: bytearray
+    decimalValues: dict
+    numericValues: dict
+    simpleCaseDeltas: dict
+    specialCasing: dict
+    unicodeDataPath: str
+    specialCasingPath: str
+
+
+def parseArgs(defaultEmit):
+    parser = argparse.ArgumentParser(description="Generate CEKF Unicode lookup data.")
+    parser.add_argument(
+        "unicodeData",
+        nargs="?",
+        default="unicode/UnicodeData.txt",
+        help="Path to UnicodeData.txt",
+    )
+    parser.add_argument(
+        "specialCasing",
+        nargs="?",
+        default="unicode/SpecialCasing.txt",
+        help="Path to SpecialCasing.txt",
+    )
+    parser.add_argument(
+        "--emit",
+        choices=("categories", "digits", "casing", "numbers"),
+        default=defaultEmit,
+        help="Generated output to emit",
+    )
+    return parser.parse_args()
+
+
+def parseCodeSequence(field):
+    stripped = field.strip()
+    if not stripped:
+        return ()
+    return tuple(int(code, 16) for code in stripped.split())
+
+
+def parseCaseDelta(code, field):
+    stripped = field.strip()
+    if not stripped:
+        return 0
+    return int(stripped, 16) - code
+
+
+def parseNumericValue(field):
+    stripped = field.strip()
+    if not stripped:
+        return None
+    if "/" in stripped:
+        return stripped
+    return int(stripped)
+
+
+def loadSpecialCasing(path):
+    mappings = {}
+
+    with open(path, encoding="utf-8") as handle:
+        for rawLine in handle:
+            line = rawLine.split("#", 1)[0].strip()
+            if not line:
+                continue
+
+            fields = [field.strip() for field in line.split(";")]
+            if len(fields) < 5:
+                raise ValueError(f"Malformed SpecialCasing.txt line: {rawLine.rstrip()}")
+
+            if fields[4]:
+                continue
+
+            code = int(fields[0], 16)
+            mappings[code] = SpecialCasing(
+                lower=parseCodeSequence(fields[1]),
+                title=parseCodeSequence(fields[2]),
+                upper=parseCodeSequence(fields[3]),
+            )
+
+    return mappings
+
+
+def applyCategoryRange(categories, start, end, category):
+    categories[start : end + 1] = bytes([category]) * (end - start + 1)
+
+
+def loadUnicodeTables(unicodeDataPath, specialCasingPath):
+    categories = bytearray([DEFAULT_CATEGORY]) * UNICODE_TABLE_SIZE
+    decimalValues = {}
+    numericValues = {}
+    simpleCaseDeltas = {}
+    specialCasing = loadSpecialCasing(specialCasingPath)
+
+    with open(unicodeDataPath, newline="", encoding="utf-8") as csvin:
+        reader = csv.reader(csvin, delimiter=";")
+        for row in reader:
+            if not row:
+                continue
+
+            code = int(row[0], 16)
+            name = row[1]
+            category = CATEGORY_VALUES[row[2]]
+
+            if name.endswith("First>"):
+                endRow = next(reader, None)
+                if endRow is None:
+                    raise ValueError(f"Missing range terminator for {row[0]}")
+                endCode = int(endRow[0], 16)
+                applyCategoryRange(categories, code, endCode, category)
+                continue
+
+            if name.endswith("Last>"):
+                continue
+
+            categories[code] = category
+
+            if row[6]:
+                decimalValues[code] = int(row[6])
+
+            numericValue = parseNumericValue(row[8])
+            if numericValue is not None:
+                numericValues[code] = numericValue
+
+            upper = parseCaseDelta(code, row[12])
+            lower = parseCaseDelta(code, row[13])
+            title = parseCaseDelta(code, row[14])
+            if upper or lower or title:
+                simpleCaseDeltas[code] = (upper, lower, title)
+
+    return UnicodeTables(
+        categories=categories,
+        decimalValues=decimalValues,
+        numericValues=numericValues,
+        simpleCaseDeltas=simpleCaseDeltas,
+        specialCasing=specialCasing,
+        unicodeDataPath=unicodeDataPath,
+        specialCasingPath=specialCasingPath,
+    )
+
+
+def buildPages(categories):
+    pageCache = {}
+    pages = []
+    pageIndex = []
+
+    for pageNumber in range(PAGE_COUNT):
+        start = pageNumber * PAGE_SIZE
+        page = bytes(categories[start : start + PAGE_SIZE])
+        index = pageCache.get(page)
+        if index is None:
+            index = len(pages)
+            pageCache[page] = index
+            pages.append(page)
+        pageIndex.append(index)
+
+    return pageIndex, pages
+
+
+def unsignedType(maxValue):
+    if maxValue <= 0xFF:
+        return "uint8_t"
+    if maxValue <= 0xFFFF:
+        return "uint16_t"
+    return "uint32_t"
+
+
+def emitIntegers(values, width, indent):
+    for offset in range(0, len(values), width):
+        chunk = values[offset : offset + width]
+        line = ", ".join(str(value) for value in chunk)
+        print(f"{indent}{line},")
+
+
+def emitQuotedStrings(values, width, indent):
+    for offset in range(0, len(values), width):
+        chunk = values[offset : offset + width]
+        line = ", ".join(valuesToCString(value) for value in chunk)
+        print(f"{indent}{line},")
+
+
+def valuesToCString(value):
+    return f'"{value}"' if value is not None else "NULL"
+
+
+def emitCategoryPage(page):
+    print("    {")
+    for offset in range(0, PAGE_SIZE, 16):
+        chunk = page[offset : offset + 16]
+        line = ", ".join(CATEGORY_NAMES[value] for value in chunk)
+        print(f"        {line},")
+    print("    },")
+
+
+def sequenceNeedsStorage(code, sequence, delta):
+    if not sequence:
+        return False
+    if len(sequence) != 1:
+        return True
+    return sequence[0] != code + delta
+
+
+def packSequence(sequence, pool, offsets):
+    offset = offsets.get(sequence)
+    if offset is not None:
+        return offset
+
+    offset = len(pool)
+    offsets[sequence] = offset
+    pool.append(len(sequence))
+    pool.extend(sequence)
+    return offset
+
+
+def emitCategories(tables):
+    pageIndex, pages = buildPages(tables.categories)
+    pageIndexType = unsignedType(len(pages) - 1)
+
+    print("/* Generated by tools/unicode_table.py")
+    print(f" * Source: {tables.unicodeDataPath}")
+    print(f" * Source: {tables.specialCasingPath}")
+    print(f" * Unique category pages: {len(pages)}")
+    print(" */")
+    print("")
+    print(
+        f"static const {pageIndexType} unicodeCategoryPageIndex[{len(pageIndex)}] = {{"
+    )
+    emitIntegers(pageIndex, 16, "    ")
+    print("};")
+    print("")
+    print(
+        f"static const unsigned char unicodeCategoryPages[{len(pages)}][{PAGE_SIZE}] = {{"
+    )
+    for page in pages:
+        emitCategoryPage(page)
+    print("};")
+
+
+def emitDigits(tables):
+    digits = sorted(tables.decimalValues.items())
+
+    print("#define UNICODE_DIGITS_CASES \\")
+    for code, value in digits:
+        print(f"    case 0x{code:04X}: return {value}; \\")
+    print("    default: return -1;")
+    print(f"#define NUM_UNICODE_DIGITS {len(digits)}")
+
+
+def emitCasing(tables):
+    specialCasePool = [0]
+    specialCaseOffsets = {}
+    records = []
+    allCodes = sorted(set(tables.simpleCaseDeltas) | set(tables.specialCasing))
+
+    for code in allCodes:
+        upperDelta, lowerDelta, titleDelta = tables.simpleCaseDeltas.get(code, (0, 0, 0))
+        special = tables.specialCasing.get(code, SpecialCasing((), (), ()))
+
+        upperSpecial = 0
+        lowerSpecial = 0
+        titleSpecial = 0
+
+        if sequenceNeedsStorage(code, special.upper, upperDelta):
+            upperSpecial = packSequence(special.upper, specialCasePool, specialCaseOffsets)
+
+        if sequenceNeedsStorage(code, special.lower, lowerDelta):
+            lowerSpecial = packSequence(special.lower, specialCasePool, specialCaseOffsets)
+
+        if sequenceNeedsStorage(code, special.title, titleDelta):
+            titleSpecial = packSequence(special.title, specialCasePool, specialCaseOffsets)
+
+        if upperDelta or lowerDelta or titleDelta or upperSpecial or lowerSpecial or titleSpecial:
+            records.append(
+                (
+                    code,
+                    upperDelta,
+                    lowerDelta,
+                    titleDelta,
+                    upperSpecial,
+                    lowerSpecial,
+                    titleSpecial,
+                )
+            )
+
+    print("/* Generated by tools/unicode_table.py */")
+    print("typedef struct {")
+    print("    uint32_t code;")
+    print("    int32_t upperDelta;")
+    print("    int32_t lowerDelta;")
+    print("    int32_t titleDelta;")
+    print("    uint32_t upperSpecial;")
+    print("    uint32_t lowerSpecial;")
+    print("    uint32_t titleSpecial;")
+    print("} UnicodeCaseEntry;")
+    print("")
+    print(f"static const uint32_t unicodeSpecialCaseData[{len(specialCasePool)}] = {{")
+    emitIntegers(specialCasePool, 12, "    ")
+    print("};")
+    print("")
+    print(f"static const UnicodeCaseEntry unicodeCaseEntries[{len(records)}] = {{")
+    for code, upperDelta, lowerDelta, titleDelta, upperSpecial, lowerSpecial, titleSpecial in records:
+        print(
+            "    {"
+            f"0x{code:04X}, {upperDelta}, {lowerDelta}, {titleDelta}, "
+            f"{upperSpecial}, {lowerSpecial}, {titleSpecial}"
+            "},"
+        )
+    print("};")
+    print(f"static const uint32_t unicodeCaseEntryCount = {len(records)};")
+
+
+def emitNumbers(tables):
+    codes = sorted(set(tables.decimalValues) | set(tables.numericValues))
+
+    print("/* Generated by tools/unicode_table.py */")
+    print("typedef struct {")
+    print("    uint32_t code;")
+    print("    int32_t decimalValue;")
+    print("    int64_t integerValue;")
+    print("    const char *fractionValue;")
+    print("    uint8_t hasIntegerValue;")
+    print("} UnicodeNumberEntry;")
+    print("")
+    print(f"static const UnicodeNumberEntry unicodeNumberEntries[{len(codes)}] = {{")
+    for code in codes:
+        decimalValue = tables.decimalValues.get(code, -1)
+        numericValue = tables.numericValues.get(code)
+        integerValue = 0
+        fractionValue = None
+        hasIntegerValue = 0
+
+        if isinstance(numericValue, int):
+            integerValue = numericValue
+            hasIntegerValue = 1
+        elif isinstance(numericValue, str):
+            fractionValue = numericValue
+
+        print(
+            "    {"
+            f"0x{code:04X}, {decimalValue}, {integerValue}, {valuesToCString(fractionValue)}, {hasIntegerValue}"
+            "},"
+        )
+    print("};")
+    print(f"static const uint32_t unicodeNumberEntryCount = {len(codes)};")
+
+
+def emit(tables, kind):
+    if kind == "categories":
+        emitCategories(tables)
+        return
+    if kind == "digits":
+        emitDigits(tables)
+        return
+    if kind == "casing":
+        emitCasing(tables)
+        return
+    if kind == "numbers":
+        emitNumbers(tables)
+        return
+    raise ValueError(f"Unsupported emit kind: {kind}")
+
+
+def main(defaultEmit="categories"):
+    args = parseArgs(defaultEmit)
+    tables = loadUnicodeTables(args.unicodeData, args.specialCasing)
+    emit(tables, args.emit)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Replace the old one-off Unicode generators with a shared Python pipeline that parses UnicodeData.txt and SpecialCasing.txt and emits category, digit, casing, and numeric tables from one source of truth.

Wire the new generated casing and numeric data into the runtime and add Unicode-aware builtins for toupper, tolower, totitle, and getnum. getnum now handles integer, decimal, and fractional Unicode numeric values, returning CEKF rationals for fraction characters.

Also fix category generation for unassigned gaps so they remain Cn instead of inheriting the previous category, update the build rules for the new generated includes, and extend Unicode regression coverage for case mapping, numeric lookup, and unassigned code points.